### PR TITLE
Add support for variable system call argument array length

### DIFF
--- a/host/agent_client.c
+++ b/host/agent_client.c
@@ -11,6 +11,9 @@
 
 int syscase_verbose = 1;
 
+// TODO: Set to 8, after OPTEE test case definition
+int syscase_max_args = 6;
+
 TEEC_Result invokeCall(TEEC_Session *sess, char* input, u_long input_size)
 {
   uint32_t err_origin;
@@ -96,11 +99,11 @@ void runTest(TEEC_Context *ctx, TEEC_Session *sess, int argc, char **argv)
   //startWork((u_long)_start, (u_long)__libc_start_main)
 
   buffer_from(&buffer, input, input_size);
-  parse_result = parse_test_case(&buffer, 3, test_case, &ncalls);
+  parse_result = parse_test_case(&buffer, 3, syscase_max_args, test_case, &ncalls);
 
   printf("read %ld bytes, parse result %d number of calls %d\n", input_size, parse_result, (int)ncalls);
   // if(parse_result == 0)
-  dump_test_case(test_case, ncalls);
+  dump_test_case(test_case, ncalls, syscase_max_args);
 
   // trace_linux_kernel()
 

--- a/host/include/syscase/test_case.h
+++ b/host/include/syscase/test_case.h
@@ -6,6 +6,7 @@
 #define BUFFER_DELIMITER "\xa5\xc9"
 #define CALL_DELIMITER "\xb7\xe3"
 
+#define NARGS 8
 #define NBUFFERS 7
 #define SIZE_STACK_SIZE 256
 
@@ -13,7 +14,7 @@ extern int syscase_verbose;
 
 struct system_call {
     u_int16_t no;
-    u_int64_t args[6];
+    u_int64_t args[NARGS];
 };
 
 struct parse_state {
@@ -47,10 +48,10 @@ int parse_argument_vector_32(struct buffer *buffer, struct parse_state *state, u
 parse_handler_t parse_map(unsigned char type);
 
 int parse_argument(struct buffer *buffer, struct parse_state *state, u_int64_t *value);
-int parse_calls(struct system_call *calls, int ncalls, struct buffer *buffer, struct system_call *value);
-int parse_test_case(struct buffer *buffer, int max_calls, test_case_t *test_case, int *ncalls);
-void dump_call(struct system_call *value);
-void dump_test_case(test_case_t *value, int n);
+int parse_calls(struct system_call *calls, int max_args, int ncalls, struct buffer *buffer, struct system_call *value);
+int parse_test_case(struct buffer *buffer, int max_calls, int max_args, test_case_t *test_case, int *ncalls);
+void dump_call(struct system_call *value, int max_args);
+void dump_test_case(test_case_t *value, int n, int max_args);
 unsigned long execute_call(struct system_call *value);
 unsigned long execute_test_case(test_case_t *value, int n);
 


### PR DESCRIPTION
Currently the number of arguments is limited to 6. [OPTEE supports up to 8 arguments](https://github.com/OP-TEE/optee_os/blob/dddb285c89e8e3db84a53cfceac65ed941fc18bd/lib/libutee/include/tee_syscall_numbers.h#L107).