### PR TITLE
Fix OPTEE system call arguments

### DIFF
--- a/syscase/optee/common.c
+++ b/syscase/optee/common.c
@@ -24,13 +24,28 @@ unsigned long sc_syscall(struct system_call *sc)
 {
   uint32_t ret;
   sc_printf("sc_syscall optee\n");
-  asm("mov x8, %[value]"
-          :
-          : [value] "r" (sc->no));
-  asm("svc #0"
-          : "=r"(ret)
-          : "r"(sc->args[0]), "r"(sc->args[1]), "r"(sc->args[2]), "r"(sc->args[3]), "r"(sc->args[4]), "r"(sc->args[5]), "r"(sc->args[6]), "r"(sc->args[7])
-          );
+  asm volatile(
+      "mov x8, %[no]\n\t"
+      "mov x0, %[a0]\n\t"
+      "mov x1, %[a1]\n\t"
+      "mov x2, %[a2]\n\t"
+      "mov x3, %[a3]\n\t"
+      "mov x4, %[a4]\n\t"
+      "mov x5, %[a5]\n\t"
+      "mov x6, %[a6]\n\t"
+      "mov x7, %[a7]\n\t"
+      "svc #0"
+      : "=r"(ret)
+      : [no] "r" (sc->no),
+        [a0] "r" (sc->args[0]),
+        [a1] "r" (sc->args[1]),
+        [a2] "r" (sc->args[2]),
+        [a3] "r" (sc->args[3]),
+        [a4] "r" (sc->args[4]),
+        [a5] "r" (sc->args[5]),
+        [a6] "r" (sc->args[6]),
+        [a7] "r" (sc->args[7])
+  );
   return ret;
 }
 


### PR DESCRIPTION
The OPTEE system call order is not as expected:
* Fix order of arguments and protect asm with `volatile`
* Merge `asm` function calls and use `volatile` to protect `asm`
* Set registers `x0-x7` explicitly
